### PR TITLE
Adds calculations for computations to be done using DPR

### DIFF
--- a/src/calculate/calculateCardinality.ts
+++ b/src/calculate/calculateCardinality.ts
@@ -1,5 +1,6 @@
 import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
 import { parseUnits } from '@ethersproject/units';
+
 import calculateTotalSupplyOfPicks from './calculateTotalSupplyOfPicks';
 
 const debug = require('debug')('pt:v4-utils-js:calculateCardinality');

--- a/src/calculate/calculateCardinality.ts
+++ b/src/calculate/calculateCardinality.ts
@@ -1,27 +1,39 @@
 import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
 import { parseUnits } from '@ethersproject/units';
+import calculateTotalSupplyOfPicks from './calculateTotalSupplyOfPicks';
 
 const debug = require('debug')('pt:v4-utils-js:calculateCardinality');
 
+/**
+ *
+ * @param bitRangeSize The size of the bit range for the draw
+ * @param totalSupply Total Supply of the Prize Pool Network
+ * @param decimals The number of decimals used to shift totalSupply. If no decimal shifting is needed ignore, default is 0.
+ * @returns
+ */
 function calculateCardinality(
     bitRangeSize: BigNumberish,
     totalSupply: BigNumberish,
-    decimals: BigNumberish
+    decimals: BigNumberish = 0
 ): number {
     const _totalSupply = BigNumber.from(totalSupply);
+
+    let cardinality = 1;
     let numberOfPicks;
-    let matchCardinality = BigNumber.from(2);
-    const range = BigNumber.from(2).pow(bitRangeSize);
-    debug('range: ', range.toString());
     do {
-        numberOfPicks = parseUnits(`${range.pow(matchCardinality)}`, decimals);
-        matchCardinality = matchCardinality.add(1);
-        debug('numberOfPicks:loop: ', numberOfPicks.toString());
+        numberOfPicks = parseUnits(
+            calculateTotalSupplyOfPicks(bitRangeSize, ++cardinality).toString(),
+            decimals
+        );
     } while (numberOfPicks.lt(_totalSupply));
-    debug('numberOfPicks: ', numberOfPicks.toString());
-    matchCardinality = matchCardinality.sub(1);
-    debug('matchCardinality: ', matchCardinality.toString());
-    return matchCardinality.toNumber();
+    cardinality--;
+
+    debug('bitRangeSize: ', BigNumber.from(bitRangeSize).toString());
+    debug('totalSupply: ', BigNumber.from(totalSupply).toString());
+    debug('decimals: ', BigNumber.from(decimals).toString());
+    debug('numberOfPicksCardinalityPlusOne: ', numberOfPicks.toString());
+    debug('cardinality: ', cardinality.toString());
+    return cardinality;
 }
 
 export default calculateCardinality;

--- a/src/calculate/calculateCardinality.ts
+++ b/src/calculate/calculateCardinality.ts
@@ -19,15 +19,18 @@ function calculateCardinality(
 ): number {
     const _totalSupply = BigNumber.from(totalSupply);
 
-    let cardinality = 1;
+    let cardinality = 0;
     let numberOfPicks;
     do {
+        cardinality++;
         numberOfPicks = parseUnits(
-            calculateTotalSupplyOfPicks(bitRangeSize, ++cardinality).toString(),
+            calculateTotalSupplyOfPicks(
+                bitRangeSize,
+                cardinality + 1
+            ).toString(),
             decimals
         );
     } while (numberOfPicks.lt(_totalSupply));
-    cardinality--;
 
     debug('bitRangeSize: ', BigNumber.from(bitRangeSize).toString());
     debug('totalSupply: ', BigNumber.from(totalSupply).toString());

--- a/src/calculate/calculateNormalizedUserBalancesFromTotalSupply.ts
+++ b/src/calculate/calculateNormalizedUserBalancesFromTotalSupply.ts
@@ -2,6 +2,12 @@ import { BigNumber } from '@ethersproject/bignumber';
 
 import { NormalizedUserBalance, UserBalance } from '../types';
 
+/**
+ * Used to calculate the normalized user balances from the total supply of a Prize Pool.
+ * @param userBalances
+ * @param totalSupply
+ * @returns
+ */
 function calculateNormalizedUserBalancesFromTotalSupply(
     userBalances: UserBalance[],
     totalSupply: BigNumber

--- a/src/calculate/calculateNumberOfPrizesPerTier.ts
+++ b/src/calculate/calculateNumberOfPrizesPerTier.ts
@@ -1,7 +1,7 @@
-import { PrizeTier } from '../types';
+import { PrizeTierConfig } from '../types';
 import calculateNumberOfPrizesForTierIndex from './calculateNumberOfPrizesForTierIndex';
 
-function calculateNumberOfPrizesPerTier(prizeTier: PrizeTier) {
+function calculateNumberOfPrizesPerTier(prizeTier: PrizeTierConfig) {
     return prizeTier.tiers.map((tier, index) =>
         !!tier
             ? calculateNumberOfPrizesForTierIndex(prizeTier.bitRangeSize, index)

--- a/src/calculate/calculateNumberOfPrizesPerTier.ts
+++ b/src/calculate/calculateNumberOfPrizesPerTier.ts
@@ -1,0 +1,12 @@
+import { PrizeTier } from '../types';
+import calculateNumberOfPrizesForTierIndex from './calculateNumberOfPrizesForTierIndex';
+
+function calculateNumberOfPrizesPerTier(prizeTier: PrizeTier) {
+    return prizeTier.tiers.map((tier, index) =>
+        !!tier
+            ? calculateNumberOfPrizesForTierIndex(prizeTier.bitRangeSize, index)
+            : 0
+    );
+}
+
+export default calculateNumberOfPrizesPerTier;

--- a/src/calculate/calculatePick.ts
+++ b/src/calculate/calculatePick.ts
@@ -3,12 +3,18 @@ import { keccak256, pack } from '@ethersproject/solidity';
 
 import { Pick } from '../types';
 
-function calculatePick(address: string, pick: BigNumberish): Pick {
-    const _pick = BigNumber.from(pick);
-    const abiEncodedValue = pack(['bytes32', 'uint256'], [address, _pick]);
+/**
+ * Calculates the random number for a pick for a user at a given index.
+ * @param address
+ * @param pickIndex
+ * @returns
+ */
+function calculatePick(address: string, pickIndex: BigNumberish): Pick {
+    const _pickIndex = BigNumber.from(pickIndex);
+    const abiEncodedValue = pack(['bytes32', 'uint256'], [address, _pickIndex]);
     const userRandomNumber = keccak256(['address'], [abiEncodedValue]);
     return {
-        index: _pick.toNumber(),
+        index: _pickIndex.toNumber(),
         hash: userRandomNumber,
     };
 }

--- a/src/calculate/calculatePicks.ts
+++ b/src/calculate/calculatePicks.ts
@@ -1,10 +1,16 @@
-import { BigNumber } from '@ethersproject/bignumber';
+import { BigNumberish } from '@ethersproject/bignumber';
 
 import { Pick } from '../types';
 import calculatePick from './calculatePick';
 
-function calculatePicks(address: string, picks: BigNumber[]): Pick[] {
-    return picks.map(pick => calculatePick(address, pick.toNumber()));
+/**
+ * Calculates the picks for a user at the give indicies
+ * @param address
+ * @param pickIndices
+ * @returns
+ */
+function calculatePicks(address: string, pickIndices: BigNumberish[]): Pick[] {
+    return pickIndices.map(pickIndex => calculatePick(address, pickIndex));
 }
 
 export default calculatePicks;

--- a/src/calculate/calculatePicksFromAverageTotalSuppliesBetween.ts
+++ b/src/calculate/calculatePicksFromAverageTotalSuppliesBetween.ts
@@ -4,6 +4,13 @@ const debug = require('debug')(
     'pt:v4-utils-js:calculatePicksFromAverageTotalSuppliesBetween'
 );
 
+/**
+ * Splits picks based on the total supply of tickets compared to other total supplies.
+ * @param totalPicks
+ * @param ticketPrimaryTotalSupply
+ * @param otherTicketsTotalSupply
+ * @returns
+ */
 function calculatePicksFromAverageTotalSuppliesBetween(
     totalPicks: number,
     ticketPrimaryTotalSupply: BigNumber,

--- a/src/calculate/calculatePrizePoolPicksWithDpr.ts
+++ b/src/calculate/calculatePrizePoolPicksWithDpr.ts
@@ -1,0 +1,77 @@
+import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
+import calculateCardinality from './calculateCardinality';
+import { calculateTotalSupplyOfPicks } from './calculateTotalSupplyOfPicks';
+
+const debug = require('debug')(
+    'pt:v4-utils-js:calculatePicksFromAverageTotalSuppliesBetween'
+);
+
+const RATE_NORMALIZATION = 1e9;
+
+/**
+ * Splits picks based on the configued DPR.
+ * @param bitRangeSize
+ * @param dpr normalized with 1e9
+ * @param minPickCost
+ * @param prizeValue
+ * @param totalSupply
+ * @param decimals (optional) unit digits to parse totalSupply with
+ * @returns
+ */
+function calculatePrizePoolPicksWithDpr(
+    bitRangeSize: number,
+    dpr: BigNumberish,
+    minPickCost: BigNumberish,
+    prizeValue: BigNumberish,
+    totalSupply: BigNumberish,
+    decimals: number | string = 0
+): number | undefined {
+    const _dpr = BigNumber.from(dpr);
+    const _totalSupply = BigNumber.from(totalSupply);
+    const _prizeValue = BigNumber.from(prizeValue);
+    const _minPickCost = BigNumber.from(minPickCost);
+
+    let targetPicks: BigNumber;
+    const odds = _dpr.mul(_totalSupply).div(_prizeValue);
+
+    if (odds.isZero()) {
+        return 0;
+    }
+
+    if (_prizeValue.gt('0')) {
+        targetPicks = _prizeValue
+            .mul(RATE_NORMALIZATION)
+            .div(_dpr.mul(_minPickCost));
+    } else {
+        targetPicks = BigNumber.from('0');
+    }
+
+    debug(`targetPicks ${Math.floor(targetPicks.toNumber())}`);
+
+    const cardinality = calculateCardinality(
+        bitRangeSize,
+        targetPicks,
+        decimals
+    );
+
+    debug(`targetPicks ${targetPicks}`);
+    debug(`cardinality ${Math.floor(cardinality)}`);
+
+    const totalNumberOfPicks = BigNumber.from(
+        calculateTotalSupplyOfPicks(bitRangeSize, cardinality)
+    );
+
+    const prizePoolNumberOfPicks = totalNumberOfPicks
+        .mul(odds)
+        .div(RATE_NORMALIZATION);
+
+    debug(
+        `prizePoolNumberOfPicks ${Math.floor(
+            prizePoolNumberOfPicks.toNumber()
+        )}`
+    );
+
+    return Math.floor(prizePoolNumberOfPicks.toNumber());
+}
+
+export default calculatePrizePoolPicksWithDpr;

--- a/src/calculate/calculatePrizePoolPicksWithDpr.ts
+++ b/src/calculate/calculatePrizePoolPicksWithDpr.ts
@@ -1,4 +1,5 @@
 import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
+
 import calculateCardinality from './calculateCardinality';
 import { calculateTotalSupplyOfPicks } from './calculateTotalSupplyOfPicks';
 

--- a/src/calculate/calculatePrizePoolPicksWithDpr.ts
+++ b/src/calculate/calculatePrizePoolPicksWithDpr.ts
@@ -25,7 +25,7 @@ function calculatePrizePoolPicksWithDpr(
     minPickCost: BigNumberish,
     prizeValue: BigNumberish,
     totalSupply: BigNumberish,
-    decimals: number | string = 0
+    decimals: BigNumberish = 0
 ): number | undefined {
     const _dpr = BigNumber.from(dpr);
     const _totalSupply = BigNumber.from(totalSupply);

--- a/src/calculate/calculateTotalSupplyOfPicks.ts
+++ b/src/calculate/calculateTotalSupplyOfPicks.ts
@@ -1,0 +1,8 @@
+import { BigNumber, BigNumberish } from 'ethers';
+
+export const calculateTotalSupplyOfPicks = (
+    bitRange: BigNumberish,
+    cardinality: number
+): number => (2 ** BigNumber.from(bitRange).toNumber()) ** cardinality;
+
+export default calculateTotalSupplyOfPicks;

--- a/src/calculate/index.ts
+++ b/src/calculate/index.ts
@@ -1,11 +1,14 @@
 export { default as calculateCardinality } from './calculateCardinality';
 export { default as calculateFractionOfPrize } from './calculateFractionOfPrize';
 export { default as calculateNormalizedBalance } from './calculateNormalizedBalance';
+export { default as calculatePrizePoolPicksWithDpr } from './calculatePrizePoolPicksWithDpr';
 export { default as calculateNormalizedBalancePicksFromTotalPicks } from './calculateNormalizedBalancePicksFromTotalPicks';
 export { default as calculateNormalizedUserBalancesFromTotalSupply } from './calculateNormalizedUserBalancesFromTotalSupply';
 export { default as calculateNumberOfMatches } from './calculateNumberOfMatches';
 export { default as calculateNumberOfPrizesForTierIndex } from './calculateNumberOfPrizesForTierIndex';
 export { default as calculatePick } from './calculatePick';
+export { default as calculateTotalSupplyOfPicks } from './calculateTotalSupplyOfPicks';
+export { default as calculateNumberOfPrizesPerTier } from './calculateNumberOfPrizesPerTier';
 export { default as calculatePicks } from './calculatePicks';
 export { default as calculatePicksFromAverageTotalSuppliesBetween } from './calculatePicksFromAverageTotalSuppliesBetween';
 export { default as calculatePrizeForTierPercentage } from './calculatePrizeForTierPercentage';

--- a/src/compute/computePrizeDistributionFromTicketAverageTotalSupplies.ts
+++ b/src/compute/computePrizeDistributionFromTicketAverageTotalSupplies.ts
@@ -52,9 +52,9 @@ async function computePrizeDistributionFromTicketAverageTotalSupplies(
     );
 
     const matchCardinality = calculateCardinality(
-        BigNumber.from(bitRangeSize),
+        bitRangeSize,
         BigNumber.from(totalAverageSupplies),
-        BigNumber.from(decimals)
+        decimals
     );
 
     let numberOfPicks;

--- a/src/compute/computePrizeDistributionFromTicketAverageTotalSupplies.ts
+++ b/src/compute/computePrizeDistributionFromTicketAverageTotalSupplies.ts
@@ -14,7 +14,7 @@ async function computePrizeDistributionFromTicketAverageTotalSupplies(
     prizeTier: PrizeTier,
     ticketPrimaryAverageTotalSupply: BigNumberish,
     ticketSecondaryListAverageTotalSupply: Array<BigNumberish>,
-    decimals: BigNumberish = 18
+    decimals: BigNumberish = 0
 ): Promise<PrizeDistribution | undefined> {
     if (
         !draw ||
@@ -78,7 +78,7 @@ async function computePrizeDistributionFromTicketAverageTotalSupplies(
         expiryDuration,
         numberOfPicks: BigNumber.from(numberOfPicks),
         startTimestampOffset: beaconPeriodSeconds,
-        endTimestampOffset: 0,
+        endTimestampOffset: prizeTier.endTimestampOffset,
         prize: prize,
     };
     debug(`computePrizeDistribution:prizeDistribution: `, prizeDistribution);

--- a/src/compute/computePrizeDistributionFromTicketAverageTotalSupplies.ts
+++ b/src/compute/computePrizeDistributionFromTicketAverageTotalSupplies.ts
@@ -9,6 +9,15 @@ const debug = require('debug')(
     'pt:v4-utils-js:computePrizeDistributionFromTicketAverageTotalSupplies'
 );
 
+/**
+ * calculatePrizeDistribution on PrizeDistributionFactory
+ * @param draw
+ * @param prizeTier
+ * @param ticketPrimaryAverageTotalSupply
+ * @param ticketSecondaryListAverageTotalSupply
+ * @param decimals
+ * @returns
+ */
 async function computePrizeDistributionFromTicketAverageTotalSupplies(
     draw: Draw,
     prizeTier: PrizeTier,

--- a/src/compute/computePrizeDistributionWithDpr.ts
+++ b/src/compute/computePrizeDistributionWithDpr.ts
@@ -1,0 +1,75 @@
+import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
+import { calculatePrizePoolPicksWithDpr } from '../calculate';
+import calculateCardinality from '../calculate/calculateCardinality';
+import { Draw, PrizeDistribution, PrizeTierV2 } from '../types';
+
+const debug = require('debug')(
+    'pt:v4-utils-js:computePrizeDistributionFromTicketAverageTotalSupplies'
+);
+
+/**
+ * Computes a full Prize Distribution for a Prize Pool Network using DPR.
+ * @param draw
+ * @param prizeTier
+ * @param prizePoolTotalSupply
+ * @param dpr
+ * @param minPickCost
+ * @param decimals
+ * @returns
+ */
+async function computePrizeDistributionWithDpr(
+    draw: Draw,
+    prizeTier: PrizeTierV2,
+    prizePoolTotalSupply: BigNumberish,
+    dpr: BigNumberish,
+    minPickCost: BigNumberish,
+    decimals: string | number = 0
+): Promise<PrizeDistribution | undefined> {
+    if (!draw || !prizeTier || !prizePoolTotalSupply) return undefined;
+
+    const { beaconPeriodSeconds } = draw;
+    const {
+        expiryDuration,
+        bitRangeSize,
+        maxPicksPerUser,
+        tiers,
+        prize,
+    } = prizeTier;
+
+    const _totalSupply = BigNumber.from(prizePoolTotalSupply);
+
+    const matchCardinality = calculateCardinality(
+        bitRangeSize,
+        _totalSupply,
+        decimals
+    );
+
+    let numberOfPicks;
+    if (_totalSupply.gt('0')) {
+        numberOfPicks = calculatePrizePoolPicksWithDpr(
+            bitRangeSize,
+            dpr,
+            minPickCost,
+            prize,
+            _totalSupply,
+            decimals
+        );
+    }
+
+    const prizeDistribution: PrizeDistribution = {
+        bitRangeSize: bitRangeSize,
+        matchCardinality,
+        tiers: tiers,
+        maxPicksPerUser: maxPicksPerUser,
+        expiryDuration,
+        numberOfPicks: BigNumber.from(numberOfPicks),
+        startTimestampOffset: beaconPeriodSeconds,
+        endTimestampOffset: 0,
+        prize: prize,
+    };
+    debug(`computePrizeDistribution:prizeDistribution: `, prizeDistribution);
+
+    return prizeDistribution;
+}
+
+export default computePrizeDistributionWithDpr;

--- a/src/compute/computePrizeDistributionWithDpr.ts
+++ b/src/compute/computePrizeDistributionWithDpr.ts
@@ -1,4 +1,5 @@
 import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
+
 import { calculatePrizePoolPicksWithDpr } from '../calculate';
 import calculateCardinality from '../calculate/calculateCardinality';
 import { Draw, PrizeDistribution, PrizeTierV2 } from '../types';

--- a/src/compute/computePrizeDistributionWithDpr.ts
+++ b/src/compute/computePrizeDistributionWithDpr.ts
@@ -12,19 +12,17 @@ const debug = require('debug')(
  * Computes a full Prize Distribution for a Prize Pool Network using DPR.
  * @param draw
  * @param prizeTier
- * @param prizePoolTotalSupply
- * @param dpr
- * @param minPickCost
- * @param decimals
+ * @param prizePoolTotalSupply average total supply for the duration of the draw provided
+ * @param minPickCost read from the contract at that time
+ * @param decimals decimals used for the Prize Pool ticket token
  * @returns
  */
 async function computePrizeDistributionWithDpr(
     draw: Draw,
     prizeTier: PrizeTierV2,
     prizePoolTotalSupply: BigNumberish,
-    dpr: BigNumberish,
     minPickCost: BigNumberish,
-    decimals: string | number = 0
+    decimals: BigNumberish = 0
 ): Promise<PrizeDistribution | undefined> {
     if (!draw || !prizeTier || !prizePoolTotalSupply) return undefined;
 
@@ -35,6 +33,7 @@ async function computePrizeDistributionWithDpr(
         maxPicksPerUser,
         tiers,
         prize,
+        dpr,
     } = prizeTier;
 
     const _totalSupply = BigNumber.from(prizePoolTotalSupply);
@@ -65,7 +64,7 @@ async function computePrizeDistributionWithDpr(
         expiryDuration,
         numberOfPicks: BigNumber.from(numberOfPicks),
         startTimestampOffset: beaconPeriodSeconds,
-        endTimestampOffset: 0,
+        endTimestampOffset: prizeTier.endTimestampOffset,
         prize: prize,
     };
     debug(`computePrizeDistribution:prizeDistribution: `, prizeDistribution);

--- a/src/compute/index.ts
+++ b/src/compute/index.ts
@@ -2,6 +2,7 @@ export { default as computeDrawResults } from './computeDrawResults';
 export { default as computePickPrize } from './computePickPrize';
 export { default as computePicksPrizes } from './computePicksPrizes';
 export { default as computePrizeAmount } from './computePrizeAmount';
+export { default as computePrizeDistributionWithDpr } from './computePrizeDistributionWithDpr';
 export { default as computePrizeDistributionFromTicketAverageTotalSupplies } from './computePrizeDistributionFromTicketAverageTotalSupplies';
 export { default as computeUserPicks } from './computeUserPicks';
 export { default as computeUserWinningPicksForRandomNumber } from './computeUserWinningPicksForRandomNumber';

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,10 @@ export type PrizeTier = {
     tiers: number[];
 };
 
+export type PrizeTierV2 = PrizeTier & {
+    dpr: number;
+};
+
 export type PrizeDistribution = PrizeTier & {
     matchCardinality: number;
     numberOfPicks: BigNumber;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,23 +2,27 @@ import { BigNumber } from '@ethersproject/bignumber';
 
 //////////////////////////// Derived from contracts ////////////////////////////
 
-export type PrizeTier = {
+export type PrizeTierConfig = {
     bitRangeSize: number;
     expiryDuration: number;
     maxPicksPerUser: number;
     prize: BigNumber;
     tiers: number[];
+    endTimestampOffset: number;
+};
+
+export type PrizeTier = PrizeTierConfig & {
+    drawId: number;
 };
 
 export type PrizeTierV2 = PrizeTier & {
     dpr: number;
 };
 
-export type PrizeDistribution = PrizeTier & {
+export type PrizeDistribution = PrizeTierConfig & {
     matchCardinality: number;
     numberOfPicks: BigNumber;
     startTimestampOffset: number;
-    endTimestampOffset: number;
 };
 
 export type Draw = {

--- a/test/calculate/calculateCardinality.test.ts
+++ b/test/calculate/calculateCardinality.test.ts
@@ -1,18 +1,35 @@
-import { parseUnits } from '@ethersproject/units';
-
-import { calculateCardinality } from '../../src';
+import calculateCardinality from '../../src/calculate/calculateCardinality';
+import { parseEther, parseUnits } from '@ethersproject/units';
 
 describe('calculateCardinality', () => {
-    it('should calculate the cardinality 22', async () => {
+    it('should calculate', async () => {
+        const cardinality = calculateCardinality(2, '1000');
+        const cardinality2 = calculateCardinality(2, '1026');
+        expect(cardinality).toEqual(4);
+        expect(cardinality2).toEqual(5);
+    });
+    it('should calculate the cardinality 21', async () => {
         const cardinality = calculateCardinality(2, parseUnits('10', 18), 6);
-        expect(cardinality).toEqual(22);
+        expect(cardinality).toEqual(21);
     });
-    it('should calculate the cardinality 8', async () => {
+    it('should calculate the cardinality 7', async () => {
         const cardinality = calculateCardinality(6, parseUnits('10', 18), 6);
-        expect(cardinality).toEqual(8);
+        expect(cardinality).toEqual(7);
     });
-    it('should calculate the cardinality 5', async () => {
+    it('should calculate the cardinality 4', async () => {
         const cardinality = calculateCardinality(10, parseUnits('10', 18), 6);
-        expect(cardinality).toEqual(5);
+        expect(cardinality).toEqual(4);
+    });
+    it('should calculate the cardinality 2', async () => {
+        const cardinality = calculateCardinality(
+            10,
+            parseEther('10000000'),
+            18
+        );
+        expect(cardinality).toEqual(2);
+    });
+    it('should calculate the cardinality 9, no decimals', async () => {
+        const cardinality = calculateCardinality(1, 753);
+        expect(cardinality).toEqual(9);
     });
 });

--- a/test/calculate/calculateCardinality.test.ts
+++ b/test/calculate/calculateCardinality.test.ts
@@ -1,5 +1,6 @@
-import calculateCardinality from '../../src/calculate/calculateCardinality';
 import { parseEther, parseUnits } from '@ethersproject/units';
+
+import calculateCardinality from '../../src/calculate/calculateCardinality';
 
 describe('calculateCardinality', () => {
     it('should calculate', async () => {

--- a/test/calculate/calculatePrizePoolPicksWithDpr.test.ts
+++ b/test/calculate/calculatePrizePoolPicksWithDpr.test.ts
@@ -1,0 +1,128 @@
+import { calculatePrizePoolPicksWithDpr } from '../../src';
+
+// https://www.notion.so/ptinc/Draw-Percentage-Rate-0fb11e1748324dd4b0fdc2f4c6b52f21
+describe('calculatePrizePoolPicksWithDpr', () => {
+    it('should calculate the number of picks', () => {
+        const dpr = 0.00015259 * 1e9; // % scaled by 1e9
+        const prizeValue = 10;
+        const bitRangeSize = 2;
+        const ticketTotalSupplyA = 500;
+        const minPickCost = 1;
+        const picksA = calculatePrizePoolPicksWithDpr(
+            bitRangeSize,
+            dpr,
+            minPickCost,
+            prizeValue,
+            ticketTotalSupplyA
+        );
+        expect(picksA).toEqual(125);
+    });
+    it('should calculate the number of picks', () => {
+        const dpr = 0.1 * 1e9; // % scaled by 1e9
+        const prizeValue = 10;
+        const bitRangeSize = 2;
+        const ticketTotalSupplyA = 1000;
+        const minPickCost = 1;
+        const picksA = calculatePrizePoolPicksWithDpr(
+            bitRangeSize,
+            dpr,
+            minPickCost,
+            prizeValue,
+            ticketTotalSupplyA
+        );
+        expect(picksA).toEqual(640);
+    });
+    it('should calculate the number of picks', () => {
+        const dpr = 0.000055 * 1e9; // % scaled by 1e9
+        const prizeValue = 10;
+        const bitRangeSize = 2;
+        const ticketTotalSupplyA = 1000;
+        const minPickCost = 1;
+        const picksA = calculatePrizePoolPicksWithDpr(
+            bitRangeSize,
+            dpr,
+            minPickCost,
+            prizeValue,
+            ticketTotalSupplyA
+        );
+        expect(picksA).toEqual(360);
+    });
+    it('should calculate the number of picks', () => {
+        const dpr = 0.00015259 * 1e9; // % scaled by 1e9
+        const prizeValue = 10;
+        const bitRangeSize = 2;
+        const ticketTotalSupplyA = 1000;
+        const minPickCost = 1;
+        const picksA = calculatePrizePoolPicksWithDpr(
+            bitRangeSize,
+            dpr,
+            minPickCost,
+            prizeValue,
+            ticketTotalSupplyA
+        );
+        expect(picksA).toEqual(250);
+    });
+    it('should calculate the number of picks', () => {
+        const dpr = 1 * 1e9; // % scaled by 1e9
+        const prizeValue = 1;
+        const bitRangeSize = 2;
+        const ticketTotalSupplyA = 1000;
+        const minPickCost = 1;
+        const picksA = calculatePrizePoolPicksWithDpr(
+            bitRangeSize,
+            dpr,
+            minPickCost,
+            prizeValue,
+            ticketTotalSupplyA
+        );
+        expect(picksA).toEqual(4000);
+    });
+    it('should calculate the number of picks', () => {
+        const dpr = 1 * 1e9; // % scaled by 1e9
+        const prizeValue = 1500;
+        const bitRangeSize = 2;
+        const ticketTotalSupplyA = 35000000;
+        const minPickCost = 1;
+        const picksA = calculatePrizePoolPicksWithDpr(
+            bitRangeSize,
+            dpr,
+            minPickCost,
+            prizeValue,
+            ticketTotalSupplyA
+        );
+        expect(picksA).toEqual(23893333);
+    });
+    it('should calculate the number of picks', () => {
+        const dpr = 16600000;
+        const prizeValue = 1000;
+        const bitRangeSize = 1;
+        const ticketTotalSupplyA = 10000;
+        const ticketTotalSupplyB = 20000;
+        const ticketTotalSupplyC = 30000;
+        const minPickCost = 80;
+        const picksA = calculatePrizePoolPicksWithDpr(
+            bitRangeSize,
+            dpr,
+            minPickCost,
+            prizeValue,
+            ticketTotalSupplyA
+        );
+        const picksB = calculatePrizePoolPicksWithDpr(
+            bitRangeSize,
+            dpr,
+            minPickCost,
+            prizeValue,
+            ticketTotalSupplyB
+        );
+        const picksC = calculatePrizePoolPicksWithDpr(
+            bitRangeSize,
+            dpr,
+            minPickCost,
+            prizeValue,
+            ticketTotalSupplyC
+        );
+        expect(picksA).toEqual(84);
+        expect(picksB).toEqual(169);
+        expect(picksC).toEqual(254);
+    });
+});

--- a/test/compute/computePickPrize.test.ts
+++ b/test/compute/computePickPrize.test.ts
@@ -30,7 +30,6 @@ describe('computePickPrize', () => {
                 0,
             ]
         );
-        console.log(pickPrize.amount.toString());
         expect(pickPrize.tierIndex).toEqual(2);
         expect(pickPrize.amount).toEqual(parseEther('0.024801587301587000'));
     });

--- a/test/compute/computePrizeDistributionFromTicketAverageTotalSupplies.test.ts
+++ b/test/compute/computePrizeDistributionFromTicketAverageTotalSupplies.test.ts
@@ -27,11 +27,14 @@ describe('computePrizeDistributionFromTicketAverageTotalSupplies', () => {
 
         const expectation = {
             bitRangeSize: 2,
-            matchCardinality: 2,
+            matchCardinality: 9,
             tiers: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             maxPicksPerUser: 2,
             expiryDuration: 86400,
-            numberOfPicks: BigNumber.from({ _hex: '0x03', _isBigNumber: true }),
+            numberOfPicks: BigNumber.from({
+                _hex: '0xcccc',
+                _isBigNumber: true,
+            }),
             startTimestampOffset: 86400,
             prize: BigNumber.from({
                 _hex: '0x5af3107a4000',
@@ -44,7 +47,8 @@ describe('computePrizeDistributionFromTicketAverageTotalSupplies', () => {
             draw,
             prizeTier,
             BigNumber.from(100000),
-            [BigNumber.from(200000), BigNumber.from(200000)]
+            [BigNumber.from(200000), BigNumber.from(200000)],
+            0
         );
 
         debug(

--- a/test/compute/computePrizeDistributionWithDpr.test.ts
+++ b/test/compute/computePrizeDistributionWithDpr.test.ts
@@ -1,11 +1,11 @@
 import { BigNumber } from '@ethersproject/bignumber';
 
-import { computePrizeDistributionFromTicketAverageTotalSupplies } from '../../src';
-import { PrizeTier } from '../../src/types';
+import { computePrizeDistributionWithDpr } from '../../src';
+import { PrizeTierV2 } from '../../src/types';
 
 const debug = require('debug')('v4-utils-js:test');
 
-describe('computePrizeDistributionFromTicketAverageTotalSupplies', () => {
+describe('computePrizeDistributionWithDpr', () => {
     it('should succeed to calculate a valid PrizeDistribution', async () => {
         const draw = {
             winningRandomNumber: BigNumber.from(
@@ -16,25 +16,25 @@ describe('computePrizeDistributionFromTicketAverageTotalSupplies', () => {
             beaconPeriodStartedAt: BigNumber.from(1634324400),
             beaconPeriodSeconds: 86400,
         };
-
-        const prizeTier: PrizeTier = {
+        const prizeTier: PrizeTierV2 = {
             bitRangeSize: 2,
             maxPicksPerUser: 2,
             expiryDuration: 86400,
             prize: BigNumber.from('100000000000000'),
             tiers: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            drawId: 100,
             endTimestampOffset: 900,
+            drawId: 100,
+            dpr: 1e9,
         };
 
         const expectation = {
             bitRangeSize: 2,
-            matchCardinality: 9,
+            matchCardinality: 8,
             tiers: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             maxPicksPerUser: 2,
             expiryDuration: 86400,
             numberOfPicks: BigNumber.from({
-                _hex: '0xcccc',
+                _hex: '0x0112e0',
                 _isBigNumber: true,
             }),
             startTimestampOffset: 86400,
@@ -45,11 +45,11 @@ describe('computePrizeDistributionFromTicketAverageTotalSupplies', () => {
             endTimestampOffset: 900,
         };
 
-        const results = await computePrizeDistributionFromTicketAverageTotalSupplies(
+        const results = await computePrizeDistributionWithDpr(
             draw,
             prizeTier,
             BigNumber.from(100000),
-            [BigNumber.from(200000), BigNumber.from(200000)],
+            1,
             0
         );
 


### PR DESCRIPTION
Adds calculations for computations to be done using DPR rather than TVL. 

- Added `PrizeTierV2` data type
- `calculateCardinality` was fixed. I had to update some old tests since `computeCardinality` was off by 1. 
- Changed a few parameters from `BigNumber` to `BigNumberish`. It's backwards compatible and supports more incoming types since we use it in a few different locations.
- Added some comments & renamed some parameters to be more explicit
- Exposed `calculateNumberOfPrizesPerTier` and `calculateTotalSupplyOfPicks`
- `PrizeTier` was previously just the intersection between the actual solidity `PrizeTier` and `PrizeDistribution`. I've renamed that type to `PrizeTierConfig` and properly typed `PrizeTier`
- Updated the `calculatePrizeDistribution` implementations to match the solidity more closely